### PR TITLE
Various fixes to FirstUse

### DIFF
--- a/qml/CountryPage.qml
+++ b/qml/CountryPage.qml
@@ -168,8 +168,6 @@ BasePage {
 
             delegate: MouseArea {
                 id: delegate
-                anchors.right: parent.right
-                anchors.left: parent.left
                 height: Units.gu(4)
                 Text {
                     id: name

--- a/qml/LicenseAgreementPage.qml
+++ b/qml/LicenseAgreementPage.qml
@@ -31,7 +31,7 @@ BasePage {
         var xhr = new XMLHttpRequest
         xhr.open("GET", "/usr/share/luneos-license-agreements/main_en.html");
         xhr.onreadystatechange = function() {
-            if (xhr.readyState == XMLHttpRequest.DONE) {
+            if (xhr.readyState === XMLHttpRequest.DONE) {
                 if(xhr.responseText !=="")
                 {
                     termsLabel.text = xhr.responseText;
@@ -42,7 +42,7 @@ BasePage {
                     var xhr2 = new XMLHttpRequest
                     xhr2.open("GET", "../test/imports/firstuse/main_en.html");
                     xhr2.onreadystatechange = function() {
-                        if (xhr.responseText == "" && xhr2.readyState == XMLHttpRequest.DONE ) {
+                        if (xhr.responseText === "" && xhr2.readyState === XMLHttpRequest.DONE ) {
                             if(xhr2.responseText !=="")
                             {
                                 termsLabel.text = xhr2.responseText;

--- a/qml/LocalePage.qml
+++ b/qml/LocalePage.qml
@@ -178,8 +178,6 @@ BasePage {
 
             delegate: MouseArea {
                 id: delegate
-                anchors.right: parent.right
-                anchors.left: parent.left
                 height: Units.gu(4)
                 Text {
                     id: name

--- a/qml/TimeZonePage.qml
+++ b/qml/TimeZonePage.qml
@@ -111,8 +111,8 @@ BasePage {
                                                    timezoneSupportsDST: timezone.supportsDST,
                                                    timezoneZoneID: timezone.ZoneID,
                                                    timezoneOffsetFromUTC: timezone.offsetFromUTC,
-                                                   timezoneOffsetSign: timezone.offsetFromUTC.toString().substring(0,1) == "-" ? "-" : "+",
-                                                   timezoneOffsetHours: timezone.offsetFromUTC.toString().substring(0,1) == "-" ? Math.floor(timezone.offsetFromUTC.toString().substring(1)/60) + ":" +(timezone.offsetFromUTC.toString().substring(1)%60+"00").substring(0,2): Math.floor(timezone.offsetFromUTC.toString()/60) + ":" +(timezone.offsetFromUTC.toString()%60+"00").substring(0,2),
+                                                   timezoneOffsetSign: timezone.offsetFromUTC.toString().substring(0,1) === "-" ? "-" : "+",
+                                                   timezoneOffsetHours: timezone.offsetFromUTC.toString().substring(0,1) === "-" ? Math.floor(timezone.offsetFromUTC.toString().substring(1)/60) + ":" +(timezone.offsetFromUTC.toString().substring(1)%60+"00").substring(0,2): Math.floor(timezone.offsetFromUTC.toString()/60) + ":" +(timezone.offsetFromUTC.toString()%60+"00").substring(0,2),
                                                    timezonePreferred: timezone.preferred ? timezone.preferred : false,
                                                    timezoneoffsetAdjustedTime: " | "+Qt.formatDateTime(offsetAdjustedTime, "h:mm")
                                                })
@@ -146,19 +146,16 @@ BasePage {
                     //Make sure we select the right one in the list
 
                     //Take the preferred one with smallest offset, regular prefered one or other available one
-                    if(currentTimezoneIndexPreferredOffset !== -1)
-					{
-						finalIndex = currentTimezoneIndexPreferredOffset;
-					}
-					else if (currentTimezoneIndexPreferred !== -1)
-					{
-						finalIndex = currentTimezoneIndexPreferred
-					}
-					else
-					{
-                        finalIndex = Math.max(currentTimezoneIndexPreferredTemp, currentTimezoneIndex);
-					}
-					
+                    if(currentTimezoneIndexPreferredOffset !== -1) {
+                        finalIndex = currentTimezoneIndexPreferredOffset;
+                    } else if (currentTimezoneIndexPreferred !== -1) {
+                        finalIndex = currentTimezoneIndexPreferred
+                    } else if (currentTimezoneIndexPreferredTemp !== -1) {
+                        finalIndex = currentTimezoneIndexPreferredTemp
+                    } else {
+                        finalIndex = currentTimezoneIndex;
+                    }
+
 					timezoneList.currentIndex = finalIndex
                     timezoneList.positionViewAtIndex(finalIndex, ListView.Center)
                     
@@ -250,9 +247,6 @@ BasePage {
 
             delegate: MouseArea {
                 id: delegate
-
-                anchors.right: parent.right
-                anchors.left: parent.left
                 height: Math.max(tzCountry.height+tzCity.height,
                                  tzDescription.height+tzOffset.height,
                                  tzCountry.height+tzDescription.height) + Units.gu(3.0)


### PR DESCRIPTION
- Remove anchors in delegates
- Fix unsafe comparison operators
- Fix selection of Timezone when no SIM card is available. It previously selected Chicago for the US, while New York was stored as preference.