### PR TITLE
WiFiPage: always show page, but adapt content

### DIFF
--- a/qml/WiFiPage.qml
+++ b/qml/WiFiPage.qml
@@ -23,6 +23,7 @@ import QtQuick.Layouts 1.0
 
 import LuneOS.Service 1.0
 import LunaNext.Common 0.1
+import Connman 0.2
 import firstuse 1.0
 
 BasePage {
@@ -121,10 +122,27 @@ BasePage {
         dynamicRoles: true
     }
 
+    //We only want to show the wifi page on devices that have acually wifi available.
+    TechnologyModel {
+        id: wifiModel
+        name: "wifi"
+    }
+    Label {
+        id: labelNoWifi
+        visible: !wifiModel.powered
+        anchors.fill: content
+        color: "white"
+        text: "No WiFi support!"
+        font.pixelSize: Units.gu(3)
+        Layout.fillHeight: false
+        Layout.preferredHeight: labelNoWifi.contentHeight
+    }
+
     ColumnLayout {
         id: column
         anchors.fill: content
         spacing: Units.gu(1)
+        visible: wifiModel.powered
 
         Label {
             id: label

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -47,7 +47,7 @@ LuneOSWindow {
 
         function gotDeviceInfoSuccess(message) {
             var response = JSON.parse(message.payload)
-            if(response.device_name==="qemux86" || response.wifi_addr==="not supported"){
+            if(response.device_name==="qemux86"){
                 pageList = [ "Welcome", "Locale", "Country", "TimeZone", "Feeds", "LicenseAgreement", "Finished" ];
             }
         }


### PR DESCRIPTION
It is not ideal to show a useless wifi page, but this will only happen on QEMU or when something's wrong.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>
