### PR TITLE
TimeZonePage.qml: Fix warning about implicitly defined properties

### DIFF
--- a/qml/TimeZonePage.qml
+++ b/qml/TimeZonePage.qml
@@ -451,7 +451,7 @@ BasePage {
 
                     Connections {
                         target: root
-                        onTzUpdated: {
+                        function onTzUpdated() {
                             var adjustedTime =  new Date();
                             adjustedTime.setUTCMinutes(adjustedTime.getUTCMinutes() + timezoneDSTCorrection + timezoneOffsetFromUTC + adjustedTime.getTimezoneOffset());
                             tzTime.text = " | " + Qt.formatTime(adjustedTime, timeFormat === "HH24"? "hh:mm": "h:mm AP");


### PR DESCRIPTION
Solves: May 26 10:14:51 qemux86-64 LunaAppManager[352]: file:///usr/palm/applications/org.webosports.app.firstuse/qml/TimeZonePage.qml:452:21: QML Connections: Implicitly defined onFoo properties in Connections are deprecated. Use this syntax instead: function onFoo(<arguments>) { ... }

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>