### PR TITLE
main.qml: Don't display the WiFi page on both qemux86 and qemux86-64

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -47,7 +47,7 @@ LuneOSWindow {
 
         function gotDeviceInfoSuccess(message) {
             var response = JSON.parse(message.payload)
-            if(response.device_name==="qemux86"){
+            if(response.device_name.substring(0,7)==="qemux86"){
                 pageList = [ "Welcome", "Locale", "Country", "TimeZone", "Feeds", "LicenseAgreement", "Finished" ];
             }
         }


### PR DESCRIPTION
We were hard checking for qemux86, now we're checking on the first 7 characters being qemux86, so it will also work for qemux86-64.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>