### PR TITLE
appinfo.json: Add "telephony.management" permissions

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -9,5 +9,5 @@
 	"useLuneOSStyle": true,
 	"trustLevel": "trusted", 
 	"loadingAnimationDisabled": true,
-	"requiredPermissions": ["ipkg-service.operation", "networkconnection.query", "networkconnection.management", "systemsettings.management", "systemsettings.query", "telephony.query", "wifi.query", "wifi.management"]
+	"requiredPermissions": ["ipkg-service.operation", "networkconnection.query", "networkconnection.management", "systemsettings.management", "systemsettings.query", "telephony.query", "telephony.management", "wifi.query", "wifi.management"]
 }


### PR DESCRIPTION
Fixes the following call and error:
service.call("luna://com.palm.wan/set", JSON.stringify({"disablewan":"off"}), setDisableWanSuccess, setDisableWanFailure)

Line  9815: Apr 28 19:43:11 mido webos-telephonyd[1740]: [] [pmlog] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"org.webosports.app.firstuse-2940","CATEGORY":"/","METHOD":"set"} Service security groups don't allow method call.